### PR TITLE
Loop through a menu

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -41,11 +41,17 @@ Menu::Menu(char* name)
 {
 }
 
-boolean Menu::next()
+boolean Menu::next(boolean loop)
 {
     if (_cur_menu_component_num != _num_menu_components - 1)
     {
         _cur_menu_component_num++;
+        _p_sel_menu_component = _menu_components[_cur_menu_component_num];
+
+        return true;
+    } else if (loop)
+    {
+        _cur_menu_component_num = 0;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
 
         return true;
@@ -54,11 +60,17 @@ boolean Menu::next()
     return false;
 }
 
-boolean Menu::prev()
+boolean Menu::prev(boolean loop)
 {
     if (_cur_menu_component_num != 0)
     {
         _cur_menu_component_num--;
+        _p_sel_menu_component = _menu_components[_cur_menu_component_num];
+
+        return true;
+    } else if (loop)
+    {
+        _cur_menu_component_num = _num_menu_components - 1;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
 
         return true;
@@ -175,14 +187,14 @@ MenuSystem::MenuSystem()
 {
 }
 
-boolean MenuSystem::next()
+boolean MenuSystem::next(boolean loop)
 {
-    return _p_curr_menu->next();
+    return _p_curr_menu->next(loop);
 }
 
-boolean MenuSystem::prev()
+boolean MenuSystem::prev(boolean loop)
 {
-    return _p_curr_menu->prev();
+    return _p_curr_menu->prev(loop);
 }
 
 void MenuSystem::select()

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -53,8 +53,8 @@ class Menu : public MenuComponent
 public:
     Menu(char* name);
 
-    boolean next();
-    boolean prev();
+    boolean next(boolean loop=false);
+    boolean prev(boolean loop=false);
     MenuComponent* activate();
     virtual MenuComponent* select();
 
@@ -84,8 +84,8 @@ class MenuSystem
 public:
     MenuSystem();
 
-    boolean next();
-    boolean prev();
+    boolean next(boolean loop=false);
+    boolean prev(boolean loop=false);
     void select();
     boolean back();
 


### PR DESCRIPTION
Hi Jon,

I've added the ability to loop through a menu with prev() and next().
The new behaviour is optional to keep compatibility with existing code.

This enables to use the menu system with just one button:
Short press to cycle through the menu and a long one to select() an item.

Cheers,
Thomas
