### PR TITLE
New display() and get_prev_menu_component_num() method

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -29,16 +29,33 @@ void MenuComponent::set_name(const char* name)
 // Menu
 // *********************************************************
 
-Menu::Menu(const char* name)
+Menu(const char* name, void (*callback)(Menu*) = NULL)
 : MenuComponent(name),
+  _disp_callback(callback),
   _p_sel_menu_component(NULL),
   _menu_components(NULL),
   _p_parent(NULL),
   _num_menu_components(0),
   _cur_menu_component_num(0),
-  _prev_menu_component_num;(0)
+  _prev_menu_component_num(0)
 {
 }
+
+
+boolean Menu::display()
+{
+    if (_disp_callback) {
+        (*_disp_callback)(this);
+        return true;
+    }
+    return false;
+}
+
+void set_display_callback(void (*callback)(Menu*))
+{
+    _disp_callback = callback;
+}
+
 
 boolean Menu::next(boolean loop)
 {
@@ -49,8 +66,7 @@ boolean Menu::next(boolean loop)
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
 
         return true;
-    } else if (loop)
-    {
+    } else if (loop) {
         _cur_menu_component_num = 0;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
 
@@ -264,4 +280,10 @@ void MenuSystem::set_root_menu(Menu* p_root_menu)
 Menu const* MenuSystem::get_current_menu() const
 {
   return _p_curr_menu;
+}
+
+boolean MenuSystem::display()
+{
+    if (_p_curr_menu != NULL) return _p_curr_menu->display();
+    return false;
 }

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -29,7 +29,7 @@ void MenuComponent::set_name(const char* name)
 // Menu
 // *********************************************************
 
-Menu(const char* name, void (*callback)(Menu*) = NULL)
+Menu::Menu(const char* name, void (*callback)(Menu*))
 : MenuComponent(name),
   _disp_callback(callback),
   _p_sel_menu_component(NULL),
@@ -51,7 +51,7 @@ boolean Menu::display()
     return false;
 }
 
-void set_display_callback(void (*callback)(Menu*))
+void Menu::set_display_callback(void (*callback)(Menu*))
 {
     _disp_callback = callback;
 }
@@ -59,7 +59,7 @@ void set_display_callback(void (*callback)(Menu*))
 
 boolean Menu::next(boolean loop)
 {
-    _prev_menu_component_num; = _cur_menu_component_num;
+    _prev_menu_component_num = _cur_menu_component_num;
     if (_cur_menu_component_num != _num_menu_components - 1)
     {
         _cur_menu_component_num++;
@@ -77,10 +77,10 @@ boolean Menu::next(boolean loop)
 
 boolean Menu::prev(boolean loop)
 {
-    _prev_menu_component_num; = _cur_menu_component_num;
+    _prev_menu_component_num = _cur_menu_component_num;
     if (_cur_menu_component_num != 0)
     {
-        cur_menu_component_num--;
+        _cur_menu_component_num--;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
 
         return true;
@@ -113,7 +113,7 @@ void Menu::reset()
 {
     for (int i = 0; i < _num_menu_components; ++i)
         _menu_components[i]->reset();
-    _prev_menu_component_num; = 0;
+    _prev_menu_component_num = 0;
     _cur_menu_component_num = 0;
     _p_sel_menu_component = _menu_components[0];
 }

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -60,7 +60,9 @@ void Menu::set_display_callback(void (*callback)(Menu*))
 boolean Menu::next(boolean loop)
 {
     _prev_menu_component_num = _cur_menu_component_num;
-    if (_cur_menu_component_num != _num_menu_components - 1)
+    if (!_num_menu_components) {
+            return false;
+    } else if (_cur_menu_component_num != _num_menu_components - 1)
     {
         _cur_menu_component_num++;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
@@ -78,7 +80,10 @@ boolean Menu::next(boolean loop)
 boolean Menu::prev(boolean loop)
 {
     _prev_menu_component_num = _cur_menu_component_num;
-    if (_cur_menu_component_num != 0)
+
+    if (!_num_menu_components) {
+            return false;
+    } else if (_cur_menu_component_num != 0)
     {
         _cur_menu_component_num--;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
@@ -96,6 +101,8 @@ boolean Menu::prev(boolean loop)
 
 MenuComponent* Menu::activate()
 {
+    if (!_num_menu_components) return NULL;
+
     MenuComponent* pComponent = _menu_components[_cur_menu_component_num];
 
     if (pComponent == NULL)
@@ -113,9 +120,10 @@ void Menu::reset()
 {
     for (int i = 0; i < _num_menu_components; ++i)
         _menu_components[i]->reset();
+
     _prev_menu_component_num = 0;
     _cur_menu_component_num = 0;
-    _p_sel_menu_component = _menu_components[0];
+    _p_sel_menu_component = _num_menu_components ? _menu_components[0] : NULL;
 }
 
 void Menu::add_item(MenuItem* pItem, void (*on_select)(MenuItem*))
@@ -253,10 +261,12 @@ void MenuSystem::select(bool reset)
 {
     MenuComponent* pComponent = _p_curr_menu->activate();
 
-    if (pComponent != NULL)
+    if (pComponent != NULL) {
         _p_curr_menu = (Menu*) pComponent;
-    else
-        if (reset) this->reset();
+    } else if (reset){
+        this->reset();
+    }
+
 }
 
 boolean MenuSystem::back()

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -35,12 +35,14 @@ Menu::Menu(const char* name)
   _menu_components(NULL),
   _p_parent(NULL),
   _num_menu_components(0),
-  _cur_menu_component_num(0)
+  _cur_menu_component_num(0),
+  _prev_menu_component_num;(0)
 {
 }
 
 boolean Menu::next(boolean loop)
 {
+    _prev_menu_component_num; = _cur_menu_component_num;
     if (_cur_menu_component_num != _num_menu_components - 1)
     {
         _cur_menu_component_num++;
@@ -54,15 +56,15 @@ boolean Menu::next(boolean loop)
 
         return true;
     }
-
     return false;
 }
 
 boolean Menu::prev(boolean loop)
 {
+    _prev_menu_component_num; = _cur_menu_component_num;
     if (_cur_menu_component_num != 0)
     {
-        _cur_menu_component_num--;
+        cur_menu_component_num--;
         _p_sel_menu_component = _menu_components[_cur_menu_component_num];
 
         return true;
@@ -73,7 +75,6 @@ boolean Menu::prev(boolean loop)
 
         return true;
     }
-
     return false;
 }
 
@@ -96,6 +97,7 @@ void Menu::reset()
 {
     for (int i = 0; i < _num_menu_components; ++i)
         _menu_components[i]->reset();
+    _prev_menu_component_num; = 0;
     _cur_menu_component_num = 0;
     _p_sel_menu_component = _menu_components[0];
 }
@@ -170,6 +172,11 @@ byte Menu::get_num_menu_components() const
 byte Menu::get_cur_menu_component_num() const
 {
     return _cur_menu_component_num;
+}
+
+byte Menu::get_prev_menu_component_num() const
+{
+    return _prev_menu_component_num;
 }
 
 // *********************************************************

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -65,6 +65,7 @@ public:
 
     byte get_num_menu_components() const;
     byte get_cur_menu_component_num() const;
+    byte get_prev_menu_component_num() const;
 
 private:
     MenuComponent* _p_sel_menu_component;
@@ -72,6 +73,7 @@ private:
     Menu* _p_parent;
     byte _num_menu_components;
     byte _cur_menu_component_num;
+    byte _prev_menu_component_num;
 };
 
 

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -46,7 +46,10 @@ private:
 class Menu : public MenuComponent
 {
 public:
-    Menu(const char* name);
+    Menu(const char* name, void (*callback)(Menu*) = NULL);
+    // returns true if there is a callbak (_disp_callback pointer not null)
+    boolean display();
+    void set_display_callback(void (*callback)(Menu*));
 
     boolean next(boolean loop=false);
     boolean prev(boolean loop=false);
@@ -74,6 +77,7 @@ private:
     byte _num_menu_components;
     byte _cur_menu_component_num;
     byte _prev_menu_component_num;
+    void (*_disp_callback)(Menu*);
 };
 
 
@@ -82,6 +86,7 @@ class MenuSystem
 public:
     MenuSystem();
 
+    boolean display();
     boolean next(boolean loop=false);
     boolean prev(boolean loop=false);
     void reset();


### PR DESCRIPTION
The `get_prev_menu_component_num()` method returns the previous menu index. This is useful for detecting which direction the user is scrolling. I am using this method in a project to print an arrow on the current row selection in an LCD menu.

The `display()` method just makes sense. In the current library implementation, there is no easy way to draw sub menu's in a different way. By tying a callback method that is responsible for drawing in with a menu object it makes it super easy to draw each menu differently. Furthermore, in my implementation, thanks to NULL pointer checking and default arguments, my changes will not break any code written with the current version of the library.

Let me know what you think,
Aaron