### PR TITLE
Added support for quad encoder + button input

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -1,9 +1,12 @@
 /*
- * Copyright (c) 2015 arduino-menusystem
+ * Copyright (c) 2015, 2016 arduino-menusystem
  * Licensed under the MIT license (see LICENSE)
  */
 
 #include "MenuSystem.h"
+#include <stdlib.h>
+
+char menuSystemTextBuffer[MENUSYSTEM_TEXTBUFFER_SIZE];
 
 // *********************************************************
 // MenuComponent
@@ -14,7 +17,7 @@ MenuComponent::MenuComponent(const char* name)
 {
 }
 
-const char* MenuComponent::get_name() const
+const char* MenuComponent::get_name()
 {
     return _name;
 }
@@ -100,7 +103,7 @@ void Menu::reset()
     _p_sel_menu_component = _menu_components[0];
 }
 
-void Menu::add_item(MenuItem* pItem, void (*on_select)(MenuItem*))
+void Menu::add_item(MenuItemBase* pItem)
 {
     // Resize menu component list, keeping existing items.
     // If it fails, there the item is not added and the function returns.
@@ -112,12 +115,16 @@ void Menu::add_item(MenuItem* pItem, void (*on_select)(MenuItem*))
 
     _menu_components[_num_menu_components] = pItem;
 
-    pItem->set_select_function(on_select);
-
     if (_num_menu_components == 0)
         _p_sel_menu_component = pItem;
 
     _num_menu_components++;
+}
+
+void Menu::add_item(MenuItem* pItem, void (*on_select)(MenuItem*))
+{
+	add_item(pItem);
+    pItem->set_select_function(on_select);
 }
 
 Menu const* Menu::get_parent() const
@@ -157,7 +164,7 @@ MenuComponent const* Menu::get_menu_component(byte index) const
   return _menu_components[index];
 }
 
-MenuComponent const* Menu::get_selected() const
+MenuComponent* Menu::get_selected() const
 {
     return _p_sel_menu_component;
 }
@@ -173,11 +180,31 @@ byte Menu::get_cur_menu_component_num() const
 }
 
 // *********************************************************
+// MenuItemBase
+// *********************************************************
+MenuItemBase::MenuItemBase(const char* name): MenuComponent(name) {
+}
+
+// *********************************************************
+// BackMenuItem
+// *********************************************************
+BackMenuItem::BackMenuItem(MenuSystem* ms, const char* name): MenuItemBase(name), menu_system(ms) {
+}
+
+MenuComponent* BackMenuItem::select()
+{
+	if (menu_system!=NULL){
+  	  menu_system->back();
+	}
+    return 0;
+}
+
+// *********************************************************
 // MenuItem
 // *********************************************************
 
 MenuItem::MenuItem(const char* name)
-: MenuComponent(name),
+: MenuItemBase(name),
   _on_select(0)
 {
 }
@@ -195,9 +222,70 @@ MenuComponent* MenuItem::select()
     return 0;
 }
 
-void MenuItem::reset()
+// *********************************************************
+// NumericMenuItem
+// *********************************************************
+
+NumericMenuItem::NumericMenuItem(const char* basename, float value, float minValue, float maxValue, float increment, void (*numberFormat)(float value, char* buffer)):
+    MenuItem(basename), _value(value), _minValue(minValue), _maxValue(maxValue), _increment(increment), _modal(false), _numberFormat(numberFormat)
 {
-    // Do nothing.
+  menuSystemTextBuffer[0] = 0;
+  if (increment < 0.0) increment = -increment;
+  if (minValue > maxValue){
+	  float tmp = maxValue;
+	  maxValue = minValue;
+	  minValue = tmp;
+  }
+};
+
+void NumericMenuItem::set_number_formatter(void (*numberFormat)(float value, char* buffer)){
+	_numberFormat = numberFormat;
+}
+
+bool NumericMenuItem::is_modal() const {
+  return _modal;
+}
+
+MenuComponent* NumericMenuItem::select() {
+  _modal = !_modal;
+  // only run _on_select when the user is done editing the value
+  if (!_modal && _on_select != NULL)
+      _on_select(this);
+  return NULL;
+}
+
+bool NumericMenuItem::modal_next(){
+  _value += _increment;
+  if (_value > _maxValue) _value = _maxValue;
+  return true;
+}
+
+bool NumericMenuItem::modal_prev(){
+  _value -= _increment;
+  if (_value < _minValue) _value = _minValue;
+  return true;
+}
+
+const char* NumericMenuItem::get_name() {
+  int i = strlen(_name);
+  memcpy( menuSystemTextBuffer, _name, i );
+  if (is_modal()) {
+	menuSystemTextBuffer[i++] = '<';
+  } else {
+	menuSystemTextBuffer[i++] = '=';
+  }
+  if (_numberFormat!=NULL) {
+    _numberFormat(_value, menuSystemTextBuffer+i);
+    i+=strlen(menuSystemTextBuffer+i);
+  } else {
+    i+=strlen(dtostrf(_value, 5, 2, menuSystemTextBuffer+i));
+  }
+
+  if (is_modal()) {
+	  menuSystemTextBuffer[i++] = '>';
+  }
+  menuSystemTextBuffer[i] = 0;
+  return menuSystemTextBuffer;
 }
 
 // *********************************************************
@@ -212,12 +300,22 @@ MenuSystem::MenuSystem()
 
 boolean MenuSystem::next(boolean loop)
 {
-    return _p_curr_menu->next(loop);
+    if (_p_curr_menu->get_selected()->is_modal()) {
+      _p_curr_menu->get_selected()->modal_next();
+      return true;
+    } else {
+      return _p_curr_menu->next(loop);
+    }
 }
 
 boolean MenuSystem::prev(boolean loop)
 {
+  if (_p_curr_menu->get_selected()->is_modal()) {
+    _p_curr_menu->get_selected()->modal_prev();
+    return true;
+  } else {
     return _p_curr_menu->prev(loop);
+  }
 }
 
 void MenuSystem::reset()
@@ -254,7 +352,7 @@ void MenuSystem::set_root_menu(Menu* p_root_menu)
     _p_curr_menu = p_root_menu;
 }
 
-Menu const* MenuSystem::get_current_menu() const
+Menu * MenuSystem::get_current_menu() const
 {
   return _p_curr_menu;
 }

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -190,7 +190,7 @@ MenuComponent* BackMenuItem::select()
 {
     if (menu_system!=NULL)
         menu_system->back();
-    return 0;
+    return NULL;
 }
 
 // *********************************************************
@@ -213,7 +213,12 @@ MenuComponent* MenuItem::select()
     if (_on_select != NULL)
         _on_select(this);
 
-    return 0;
+    return NULL;
+}
+
+void MenuItem::reset()
+{
+    // Do nothing
 }
 
 // *********************************************************
@@ -223,63 +228,62 @@ MenuComponent* MenuItem::select()
 NumericMenuItem::NumericMenuItem(const char* basename, float value, float minValue, float maxValue, float increment, void (*numberFormat)(float value, char* buffer)):
     MenuItem(basename), _value(value), _minValue(minValue), _maxValue(maxValue), _increment(increment), _modal(false), _numberFormat(numberFormat)
 {
-  menuSystemTextBuffer[0] = 0;
-  if (increment < 0.0) increment = -increment;
-  if (minValue > maxValue){
-	  float tmp = maxValue;
-	  maxValue = minValue;
-	  minValue = tmp;
-  }
+    menuSystemTextBuffer[0] = 0;
+    if (increment < 0.0) increment = -increment;
+    if (minValue > maxValue)
+    {
+        float tmp = maxValue;
+        maxValue = minValue;
+        minValue = tmp;
+    }
 };
 
 void NumericMenuItem::set_number_formatter(void (*numberFormat)(float value, char* buffer)){
-	_numberFormat = numberFormat;
+    _numberFormat = numberFormat;
 }
 
 bool NumericMenuItem::is_modal() const {
-  return _modal;
+    return _modal;
 }
 
 MenuComponent* NumericMenuItem::select() {
-  _modal = !_modal;
-  // only run _on_select when the user is done editing the value
-  if (!_modal && _on_select != NULL)
-      _on_select(this);
-  return NULL;
+    _modal = !_modal;
+    // only run _on_select when the user is done editing the value
+    if (!_modal && _on_select != NULL)
+        _on_select(this);
+    return NULL;
 }
 
-bool NumericMenuItem::modal_next(){
-  _value += _increment;
-  if (_value > _maxValue) _value = _maxValue;
-  return true;
+bool NumericMenuItem::modal_next() {
+    _value += _increment;
+    if (_value > _maxValue) _value = _maxValue;
+    return true;
 }
 
-bool NumericMenuItem::modal_prev(){
-  _value -= _increment;
-  if (_value < _minValue) _value = _minValue;
-  return true;
+bool NumericMenuItem::modal_prev() {
+    _value -= _increment;
+    if (_value < _minValue) _value = _minValue;
+    return true;
 }
 
 const char* NumericMenuItem::get_name() const {
-  int i = strlen(_name);
-  memcpy( menuSystemTextBuffer, _name, i );
-  if (is_modal()) {
-	menuSystemTextBuffer[i++] = '<';
-  } else {
-	menuSystemTextBuffer[i++] = '=';
-  }
-  if (_numberFormat!=NULL) {
-    _numberFormat(_value, menuSystemTextBuffer+i);
-    i+=strlen(menuSystemTextBuffer+i);
-  } else {
-    i+=strlen(dtostrf(_value, 5, 2, menuSystemTextBuffer+i));
-  }
+    int i = strlen(_name);
+    memcpy( menuSystemTextBuffer, _name, i );
+    if (is_modal())
+        menuSystemTextBuffer[i++] = '<';
+    else 
+        menuSystemTextBuffer[i++] = '=';
+    
+    if (_numberFormat!=NULL) {
+        _numberFormat(_value, menuSystemTextBuffer+i);
+        i+=strlen(menuSystemTextBuffer+i);
+    } else 
+        i+=strlen(dtostrf(_value, 5, 2, menuSystemTextBuffer+i));
 
-  if (is_modal()) {
-	  menuSystemTextBuffer[i++] = '>';
-  }
-  menuSystemTextBuffer[i] = 0;
-  return menuSystemTextBuffer;
+    if (is_modal())
+        menuSystemTextBuffer[i++] = '>';
+    menuSystemTextBuffer[i] = 0;
+    return menuSystemTextBuffer;
 }
 
 // *********************************************************
@@ -348,5 +352,5 @@ void MenuSystem::set_root_menu(Menu* p_root_menu)
 
 Menu * MenuSystem::get_current_menu() const
 {
-  return _p_curr_menu;
+    return _p_curr_menu;
 }

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -17,7 +17,7 @@ MenuComponent::MenuComponent(const char* name)
 {
 }
 
-const char* MenuComponent::get_name()
+const char* MenuComponent::get_name() const
 {
     return _name;
 }
@@ -266,7 +266,7 @@ bool NumericMenuItem::modal_prev(){
   return true;
 }
 
-const char* NumericMenuItem::get_name() {
+const char* NumericMenuItem::get_name() const {
   int i = strlen(_name);
   memcpy( menuSystemTextBuffer, _name, i );
   if (is_modal()) {

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -277,7 +277,7 @@ bool NumericMenuItem::modal_prev()
 
 String& NumericMenuItem::get_composite_name(String& buffer) const 
 {
-    buffer += _name;
+    buffer = _name;
     buffer += is_modal()?'<':'=';
     
     if (_numberFormat!=NULL)

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -188,6 +188,8 @@ BackMenuItem::BackMenuItem(MenuSystem* ms, const char* name): MenuItem(name), me
 
 MenuComponent* BackMenuItem::select()
 {
+	if (_on_select!=NULL)
+		_on_select(this);
     if (menu_system!=NULL)
         menu_system->back();
     return NULL;
@@ -218,7 +220,7 @@ MenuComponent* MenuItem::select()
 
 void MenuItem::reset()
 {
-    // Do nothing
+    // Do nothing.
 }
 
 // *********************************************************
@@ -350,7 +352,7 @@ void MenuSystem::set_root_menu(Menu* p_root_menu)
     _p_curr_menu = p_root_menu;
 }
 
-Menu * MenuSystem::get_current_menu() const
+Menu const* MenuSystem::get_current_menu() const
 {
     return _p_curr_menu;
 }

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -25,7 +25,7 @@ public:
     MenuComponent(const char* name);
 
     void set_name(const char* name);
-    virtual const char* get_name();
+    virtual const char* get_name() const;
 
     virtual MenuComponent* select() = 0;
     virtual void reset() = 0;
@@ -83,7 +83,7 @@ public:
   NumericMenuItem(const char* basename, float value, float minValue, float maxValue, float increment=1.0, void (*numberFormat)(float value, char* buffer)=NULL );
   void set_number_formatter(void (*numberFormat)(float value, char* buffer));
   virtual MenuComponent* select();
-  virtual const char* get_name();
+  virtual const char* get_name() const;
   float get_value() {return _value;}
   virtual bool is_modal() const;
 

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 arduino-menusystem
+ * Copyright (c) 2015, 2016 arduino-menusystem
  * Licensed under the MIT license (see LICENSE)
  */
 
@@ -12,23 +12,58 @@
   #include <WProgram.h>
 #endif
 
+#ifndef MENUSYSTEM_TEXTBUFFER_SIZE
+#define MENUSYSTEM_TEXTBUFFER_SIZE 20
+#endif
+
+class MenuSystem;
+//extern char menuSystemTextBuffer[MENUSYSTEM_TEXTBUFFER_SIZE];
+
 class MenuComponent
 {
 public:
     MenuComponent(const char* name);
 
     void set_name(const char* name);
-    const char* get_name() const;
+    virtual const char* get_name();
 
     virtual MenuComponent* select() = 0;
     virtual void reset() = 0;
+
+    // modal methods
+    virtual bool is_modal() const {return false;}
+    virtual bool modal_next() {return false;}
+    virtual bool modal_prev() {return false;}
 
 protected:
     const char* _name;
 };
 
+/**
+ * virtual base class for BackMenuItem and MenuItem
+ */
+class MenuItemBase : public MenuComponent
+{
+public:
+	MenuItemBase(const char* name);
+	virtual MenuComponent* select() = 0;
+	virtual void reset() {}
+};
 
-class MenuItem : public MenuComponent
+/**
+ * This is a menu item that will execute MenuSystem::back() when selected.
+ */
+class BackMenuItem : public MenuItemBase
+{
+public:
+	BackMenuItem(MenuSystem* ms, const char* name = "back");
+
+    virtual MenuComponent* select();
+protected:
+    MenuSystem* menu_system;
+};
+
+class MenuItem : public MenuItemBase
 {
 public:
     MenuItem(const char* name);
@@ -36,12 +71,34 @@ public:
     void set_select_function(void (*on_select)(MenuItem*));
 
     virtual MenuComponent* select();
-    virtual void reset();
 
-private:
+protected:
     void (*_on_select)(MenuItem*);
 };
 
+
+class NumericMenuItem : public MenuItem
+{
+public:
+  NumericMenuItem(const char* basename, float value, float minValue, float maxValue, float increment=1.0, void (*numberFormat)(float value, char* buffer)=NULL );
+  void set_number_formatter(void (*numberFormat)(float value, char* buffer));
+  virtual bool is_modal() const;
+  virtual bool modal_next();
+  virtual bool modal_prev();
+  virtual MenuComponent* select();
+  virtual const char* get_name();
+  float get_value() {return _value;}
+
+protected:
+
+  float _value;
+  //char _valueAsText[NUMERIC_MENU_ITEM_BUFFER];
+  float _minValue;
+  float _maxValue;
+  float _increment;
+  bool _modal;
+  void (*_numberFormat)(float value, char* buffer);
+};
 
 class Menu : public MenuComponent
 {
@@ -54,13 +111,14 @@ public:
     virtual MenuComponent* select();
     virtual void reset();
 
+    void add_item(MenuItemBase* pItem);
     void add_item(MenuItem* pItem, void (*on_select)(MenuItem*));
     Menu const* add_menu(Menu* pMenu);
 
     void set_parent(Menu* pParent);
     Menu const* get_parent() const;
 
-    MenuComponent const* get_selected() const;
+    MenuComponent* get_selected() const;
     MenuComponent const* get_menu_component(byte index) const;
 
     byte get_num_menu_components() const;
@@ -88,7 +146,7 @@ public:
 
     void set_root_menu(Menu* p_root_menu);
 
-    Menu const* get_current_menu() const;
+    Menu * get_current_menu() const;
 
 private:
     Menu* _p_root_menu;

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -28,7 +28,7 @@ public:
     /* returns _name + _value concatenation if applicable */
     virtual const char* get_name() const;
     /* returns the un-altered name assigned by set_name() */
-    const char* get_base_name() { return _name; }
+    const char* get_base_name() const { return _name; }
 
     virtual MenuComponent* select() = 0;
     virtual void reset() = 0;

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -17,10 +17,10 @@
 #endif
 
 class MenuSystem;
-//extern char menuSystemTextBuffer[MENUSYSTEM_TEXTBUFFER_SIZE];
 
 class MenuComponent
 {
+	friend class MenuSystem;
 public:
     MenuComponent(const char* name);
 
@@ -29,13 +29,13 @@ public:
 
     virtual MenuComponent* select() = 0;
     virtual void reset() = 0;
-
     // modal methods
     virtual bool is_modal() const {return false;}
+
+protected:
     virtual bool modal_next() {return false;}
     virtual bool modal_prev() {return false;}
 
-protected:
     const char* _name;
 };
 
@@ -82,14 +82,14 @@ class NumericMenuItem : public MenuItem
 public:
   NumericMenuItem(const char* basename, float value, float minValue, float maxValue, float increment=1.0, void (*numberFormat)(float value, char* buffer)=NULL );
   void set_number_formatter(void (*numberFormat)(float value, char* buffer));
-  virtual bool is_modal() const;
-  virtual bool modal_next();
-  virtual bool modal_prev();
   virtual MenuComponent* select();
   virtual const char* get_name();
   float get_value() {return _value;}
+  virtual bool is_modal() const;
 
 protected:
+  virtual bool modal_next();
+  virtual bool modal_prev();
 
   float _value;
   //char _valueAsText[NUMERIC_MENU_ITEM_BUFFER];

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -13,14 +13,14 @@
 #endif
 
 #ifndef MENUSYSTEM_TEXTBUFFER_SIZE
-#define MENUSYSTEM_TEXTBUFFER_SIZE 20
+#define MENUSYSTEM_TEXTBUFFER_SIZE 40
 #endif
 
 class MenuSystem;
 
 class MenuComponent
 {
-	friend class MenuSystem;
+    friend class MenuSystem;
 public:
     MenuComponent(const char* name);
 
@@ -39,31 +39,7 @@ protected:
     const char* _name;
 };
 
-/**
- * virtual base class for BackMenuItem and MenuItem
- */
-class MenuItemBase : public MenuComponent
-{
-public:
-	MenuItemBase(const char* name);
-	virtual MenuComponent* select() = 0;
-	virtual void reset() {}
-};
-
-/**
- * This is a menu item that will execute MenuSystem::back() when selected.
- */
-class BackMenuItem : public MenuItemBase
-{
-public:
-	BackMenuItem(MenuSystem* ms, const char* name = "back");
-
-    virtual MenuComponent* select();
-protected:
-    MenuSystem* menu_system;
-};
-
-class MenuItem : public MenuItemBase
+class MenuItem : public MenuComponent
 {
 public:
     MenuItem(const char* name);
@@ -71,11 +47,24 @@ public:
     void set_select_function(void (*on_select)(MenuItem*));
 
     virtual MenuComponent* select();
+    virtual void reset();
 
 protected:
     void (*_on_select)(MenuItem*);
 };
 
+/**
+ * This is a menu item that will execute MenuSystem::back() when selected.
+ */
+class BackMenuItem : public MenuItem
+{
+public:
+    BackMenuItem(MenuSystem* ms, const char* name = "back");
+
+    virtual MenuComponent* select();
+protected:
+    MenuSystem* menu_system;
+};
 
 class NumericMenuItem : public MenuItem
 {
@@ -92,7 +81,6 @@ protected:
   virtual bool modal_prev();
 
   float _value;
-  //char _valueAsText[NUMERIC_MENU_ITEM_BUFFER];
   float _minValue;
   float _maxValue;
   float _increment;
@@ -102,6 +90,7 @@ protected:
 
 class Menu : public MenuComponent
 {
+    friend class MenuSystem;
 public:
     Menu(const char* name);
 
@@ -111,19 +100,20 @@ public:
     virtual MenuComponent* select();
     virtual void reset();
 
-    void add_item(MenuItemBase* pItem);
-    void add_item(MenuItem* pItem, void (*on_select)(MenuItem*));
+    void add_item(MenuItem* pItem, void (*on_select)(MenuItem*) = NULL);
     Menu const* add_menu(Menu* pMenu);
 
     void set_parent(Menu* pParent);
     Menu const* get_parent() const;
 
-    MenuComponent* get_selected() const;
+    MenuComponent const* get_selected() const;
     MenuComponent const* get_menu_component(byte index) const;
 
     byte get_num_menu_components() const;
     byte get_cur_menu_component_num() const;
-
+protected:
+    // non-const version of get_selected()
+    MenuComponent* get_selected_nc() const;
 private:
     MenuComponent* _p_sel_menu_component;
     MenuComponent** _menu_components;

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -136,7 +136,7 @@ public:
 
     void set_root_menu(Menu* p_root_menu);
 
-    Menu * get_current_menu() const;
+    Menu const* get_current_menu() const;
 
 private:
     Menu* _p_root_menu;

--- a/examples/serial_nav/serial_nav.ino
+++ b/examples/serial_nav/serial_nav.ino
@@ -120,6 +120,7 @@ void loop()
 }
 
 void displayMenu() {
+  String buffer;
   Serial.println("");
   // Display the menu
   Menu const* cp_menu = ms.get_current_menu();
@@ -131,8 +132,7 @@ void displayMenu() {
   for (int i = 0; i < cp_menu->get_num_menu_components(); ++i)
   {
     MenuComponent const* cp_m_comp = cp_menu->get_menu_component(i);
-    String s;
-    Serial.print(cp_m_comp->get_composite_name(s));
+    Serial.print(cp_m_comp->get_composite_name(buffer));
 
     if (cp_menu_sel == cp_m_comp)
       Serial.print("<<< ");

--- a/examples/serial_nav/serial_nav.ino
+++ b/examples/serial_nav/serial_nav.ino
@@ -9,16 +9,52 @@
 
 #include <MenuSystem.h>
 
+// forward declarations
+void floatMenuFormat(float value, char* buffer);
+void intMenuFormat(float value, char* buffer);
+void colorMenuFormat(float value, char* buffer);
+
 // Menu variables
 MenuSystem ms;
 Menu mm("ROOT Menu Title");
 MenuItem mm_mi1("Level 1 - Item 1 (Item)");
 MenuItem mm_mi2("Level 1 - Item 2 (Item)");
 Menu mu1("Level 1 - Item 3 (Menu)");
+BackMenuItem mu1_mi0(&ms, "Level 2 - Back (Item)");
 MenuItem mu1_mi1("Level 2 - Item 1 (Item)");
-
+NumericMenuItem mm_mi3("Level 1 - NumericItem 3 (Item)", 0.5, 0.0, 1.0, 0.1, floatMenuFormat);
+NumericMenuItem mm_mi4("Level 1 - NumericItem 4 (Item)", 50, -100, 100, 1, intMenuFormat);
+NumericMenuItem mm_mi5("Level 1 - NumericItem 5 (Item)", 0, 0, 2, 1, colorMenuFormat);
 
 // Menu callback function
+
+// writes the (int) value of a float into a char buffer.
+void intMenuFormat(float value, char* buffer) 
+{
+  sprintf(buffer, "%d", (int)value);
+}
+
+// writes the value of a float into a char buffer.
+void floatMenuFormat(float value, char* buffer) 
+{
+  dtostrf(value, 3, 2, buffer);
+}
+
+// writes the value of a float into a char buffer as predefined colors.
+void colorMenuFormat(float value, char* buffer) 
+{
+  switch((int) value) {
+    case 0: sprintf(buffer,"Red");
+      break;
+    case 1: sprintf(buffer,"Green");
+      break;
+    case 2: sprintf(buffer,"Blue");
+      break;
+    default:
+      sprintf(buffer,"undef");
+  }
+}
+
 // In this example all menu items use the same callback.
 
 void on_item1_selected(MenuItem* p_menu_item)
@@ -55,7 +91,11 @@ void setup()
   mm.add_item(&mm_mi1, &on_item1_selected);
   mm.add_item(&mm_mi2, &on_item2_selected);
   mm.add_menu(&mu1);
+  mu1.add_item(&mu1_mi0);
   mu1.add_item(&mu1_mi1, &on_item3_selected);
+  mm.add_item(&mm_mi3);
+  mm.add_item(&mm_mi4);
+  mm.add_item(&mm_mi5);
   ms.set_root_menu(&mm);
   Serial.println("Menu setted.");
   displayMenu();
@@ -130,6 +170,5 @@ void serialPrintHelp() {
   Serial.println("?: print this help");
   Serial.println("h: print this help");
   Serial.println("***************");
-
 }
 

--- a/examples/serial_nav/serial_nav.ino
+++ b/examples/serial_nav/serial_nav.ino
@@ -10,9 +10,9 @@
 #include <MenuSystem.h>
 
 // forward declarations
-void floatMenuFormat(float value, char* buffer);
-void intMenuFormat(float value, char* buffer);
-void colorMenuFormat(float value, char* buffer);
+void floatMenuFormat(float value, char* buffer, uint16_t buffer_size);
+void intMenuFormat(float value, char* buffer, uint16_t buffer_size);
+void colorMenuFormat(float value, char* buffer, uint16_t buffer_size);
 
 // Menu variables
 MenuSystem ms;
@@ -30,20 +30,23 @@ NumericMenuItem mm_mi5("Level 1 - Int Item 5 (Item)", 50, -100, 100, 1, intMenuF
 // Menu callback function
 
 // writes the (int) value of a float into a char buffer.
-void intMenuFormat(float value, char* buffer) 
+void intMenuFormat(float value, char* buffer, uint16_t buffer_size) 
 {
+  // TODO check buffer size 
   sprintf(buffer, "%d", (int)value);
 }
 
 // writes the value of a float into a char buffer.
-void floatMenuFormat(float value, char* buffer) 
+void floatMenuFormat(float value, char* buffer, uint16_t buffer_size) 
 {
+  // TODO check buffer size 
   dtostrf(value, 3, 2, buffer);
 }
 
 // writes the value of a float into a char buffer as predefined colors.
-void colorMenuFormat(float value, char* buffer) 
+void colorMenuFormat(float value, char* buffer, uint16_t buffer_size) 
 {
+  // TODO check buffer size 
   switch((int) value) {
     case 0: sprintf(buffer,"Red");
       break;

--- a/examples/serial_nav/serial_nav.ino
+++ b/examples/serial_nav/serial_nav.ino
@@ -22,9 +22,10 @@ MenuItem mm_mi2("Level 1 - Item 2 (Item)");
 Menu mu1("Level 1 - Item 3 (Menu)");
 BackMenuItem mu1_mi0(&ms, "Level 2 - Back (Item)");
 MenuItem mu1_mi1("Level 2 - Item 1 (Item)");
-NumericMenuItem mm_mi3("Level 1 - NumericItem 3 (Item)", 0.5, 0.0, 1.0, 0.1, floatMenuFormat);
-NumericMenuItem mm_mi4("Level 1 - NumericItem 4 (Item)", 50, -100, 100, 1, intMenuFormat);
-NumericMenuItem mm_mi5("Level 1 - NumericItem 5 (Item)", 0, 0, 2, 1, colorMenuFormat);
+NumericMenuItem mu1_mi2("Level 2 - Txt Item 2 (Item)", 0, 0, 2, 1, colorMenuFormat);
+NumericMenuItem mm_mi4("Level 1 - Float Item 4 (Item)", 0.5, 0.0, 1.0, 0.1, floatMenuFormat);
+NumericMenuItem mm_mi5("Level 1 - Int Item 5 (Item)", 50, -100, 100, 1, intMenuFormat);
+
 
 // Menu callback function
 
@@ -72,6 +73,11 @@ void on_item3_selected(MenuItem* p_menu_item)
   Serial.println("Item3 Selected");
 }
 
+void on_back_item_selected(MenuItem* p_menu_item)
+{
+  Serial.println("Back item Selected");
+}
+
 // Standard arduino functions
 
 void setup()
@@ -91,11 +97,13 @@ void setup()
   mm.add_item(&mm_mi1, &on_item1_selected);
   mm.add_item(&mm_mi2, &on_item2_selected);
   mm.add_menu(&mu1);
-  mu1.add_item(&mu1_mi0);
+  // the on_select callback is optional on a BackMenuItem
+  mu1.add_item(&mu1_mi0, &on_back_item_selected);
   mu1.add_item(&mu1_mi1, &on_item3_selected);
-  mm.add_item(&mm_mi3);
+  mu1.add_item(&mu1_mi2);
   mm.add_item(&mm_mi4);
   mm.add_item(&mm_mi5);
+ 
   ms.set_root_menu(&mm);
   Serial.println("Menu setted.");
   displayMenu();

--- a/examples/serial_nav/serial_nav.ino
+++ b/examples/serial_nav/serial_nav.ino
@@ -10,9 +10,9 @@
 #include <MenuSystem.h>
 
 // forward declarations
-void floatMenuFormat(float value, char* buffer, uint16_t buffer_size);
-void intMenuFormat(float value, char* buffer, uint16_t buffer_size);
-void colorMenuFormat(float value, char* buffer, uint16_t buffer_size);
+void floatMenuFormat(const NumericMenuItem& menuitem, String& buffer);
+void intMenuFormat(const NumericMenuItem& menuitem, String& buffer);
+void colorMenuFormat(const NumericMenuItem& menuitem, String& buffer);
 
 // Menu variables
 MenuSystem ms;
@@ -30,32 +30,30 @@ NumericMenuItem mm_mi5("Level 1 - Int Item 5 (Item)", 50, -100, 100, 1, intMenuF
 // Menu callback function
 
 // writes the (int) value of a float into a char buffer.
-void intMenuFormat(float value, char* buffer, uint16_t buffer_size) 
+void intMenuFormat(const NumericMenuItem& menuitem, String& buffer) 
 {
-  // TODO check buffer size 
-  sprintf(buffer, "%d", (int)value);
+  buffer += String((int)menuitem.get_value());
 }
 
 // writes the value of a float into a char buffer.
-void floatMenuFormat(float value, char* buffer, uint16_t buffer_size) 
+void floatMenuFormat(const NumericMenuItem& menuitem, String& buffer) 
 {
-  // TODO check buffer size 
-  dtostrf(value, 3, 2, buffer);
+  buffer += String(menuitem.get_value());
 }
 
 // writes the value of a float into a char buffer as predefined colors.
-void colorMenuFormat(float value, char* buffer, uint16_t buffer_size) 
+void colorMenuFormat(const NumericMenuItem& menuitem, String& buffer) 
 {
   // TODO check buffer size 
-  switch((int) value) {
-    case 0: sprintf(buffer,"Red");
+  switch((int) menuitem.get_value()) {
+    case 0: buffer += "Red";
       break;
-    case 1: sprintf(buffer,"Green");
+    case 1: buffer += "Green";
       break;
-    case 2: sprintf(buffer,"Blue");
+    case 2: buffer += "Blue";
       break;
     default:
-      sprintf(buffer,"undef");
+      buffer += "undef";
   }
 }
 
@@ -128,12 +126,13 @@ void displayMenu() {
 
   Serial.print("Current menu name: ");
   Serial.println(cp_menu->get_name());
-
+  
   MenuComponent const* cp_menu_sel = cp_menu->get_selected();
   for (int i = 0; i < cp_menu->get_num_menu_components(); ++i)
   {
     MenuComponent const* cp_m_comp = cp_menu->get_menu_component(i);
-    Serial.print(cp_m_comp->get_name());
+    String s;
+    Serial.print(cp_m_comp->get_composite_name(s));
 
     if (cp_menu_sel == cp_m_comp)
       Serial.print("<<< ");

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,6 @@
 Menu            KEYWORD1
 MenuItem        KEYWORD1
+NumericMenuItem KEYWORD1
+BackMenuItem    KEYWORD1
 MenuSystem      KEYWORD1
 MenuComponent   KEYWORD1


### PR DESCRIPTION
* added a menu item that has a 'numeric modal' mode, in this mode it uses `next()` and `prev()` input to increase and decrease its numeric value. `select()` toggles the modal mode.
* added a menu item that only does 'MenuSystem::back()' when selected.
* made it possible for a menu item to change name at any time (by removing`const`from a few places). E.g. this way we can have menuitems that toggles start/stop etc, etc.  

With these changes it is possible to control the entire menu system with just`up`,`down`and`select` (or forward and backward rotation + a button)
I understand that these changes are quite extensive. And they could possibly have been implemented in a different way. This is just a suggestion.

regards
@eadf