### PR TITLE
Add is_current to MenuComponent and add min, max parameters in set_value

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -13,7 +13,8 @@
 
 MenuComponent::MenuComponent(const char* name)
 : _name(name),
-  _has_focus(false)
+  _has_focus(false),
+  _is_current(false)
 {
 }
 
@@ -30,6 +31,21 @@ void MenuComponent::set_name(const char* name)
 bool MenuComponent::has_focus() const
 {
     return _has_focus;
+}
+
+bool MenuComponent::is_current() const
+{
+    return _is_current;
+}
+
+void MenuComponent::set_current()
+{
+    _is_current = true;
+}
+
+void MenuComponent::set_previous()
+{
+    _is_current = false;
 }
 
 // *********************************************************
@@ -60,6 +76,8 @@ bool Menu::next(bool loop)
         _current_component_num++;
         _p_current_component = _menu_components[_current_component_num];
 
+        _p_current_component->set_current();
+        _menu_components[_previous_component_num]->set_previous();
         return true;
     }
     else if (loop)
@@ -67,6 +85,9 @@ bool Menu::next(bool loop)
         _current_component_num = 0;
         _p_current_component = _menu_components[_current_component_num];
 
+        _p_current_component->set_current();
+        _menu_components[_previous_component_num]->set_previous();
+        
         return true;
     }
     return false;
@@ -84,6 +105,9 @@ bool Menu::prev(bool loop)
     {
         _current_component_num--;
         _p_current_component = _menu_components[_current_component_num];
+        
+        _p_current_component->set_current();
+        _menu_components[_previous_component_num]->set_previous();
 
         return true;
     }
@@ -91,6 +115,9 @@ bool Menu::prev(bool loop)
     {
         _current_component_num = _num_components - 1;
         _p_current_component = _menu_components[_current_component_num];
+        
+        _p_current_component->set_current();
+        _menu_components[_previous_component_num]->set_previous();
 
         return true;
     }

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -369,9 +369,11 @@ String NumericMenuItem::get_value_string() const
     return buffer;
 }
 
-void NumericMenuItem::set_value(float value)
+void NumericMenuItem::set_value(float value, float min, float max)
 {
     _value = value;
+    _minValue = min;
+    _maxValue = max;
 }
 
 

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -83,6 +83,25 @@ public:
     //! \see MenuComponent::select
     //! \see NumericMenuComponent
     bool has_focus() const;
+    
+    //! \brief Returns true if this is the current component; false otherwise
+    //!
+    //! This bool registers if the component is the current selected component.
+    //!
+    //! Subclasses should use set_current() when the component becomes activated
+    //! and use set_previous() once the component is no longer the current component.
+    //!
+    //! \returns true if this component is the current component, false otherwise.
+    //!
+    //! \see MenuComponent::set_current
+    //! \see MenuComponent::set_previous
+    bool is_current() const;
+    
+    //! \brief Set the current state of the component to true
+    void set_current();
+    
+    //! \brief Set the current state of the component to false
+    void set_previous();
 
 protected:
     //! \brief Processes the next action
@@ -145,6 +164,7 @@ protected:
 protected:
     const char* _name;
     bool _has_focus;
+    bool _is_current;
 };
 
 

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -278,7 +278,7 @@ public:
     float get_maxValue() const;
 
     String get_value_string() const;
-    void set_value(float value);
+    void set_value(float value, float min, float max);
 
     virtual void render(MenuComponentRenderer const& renderer) const;
 


### PR DESCRIPTION
Hi dear Jon,

Thanks for the awesome library! It is beautiful.

For writing only the current highlighted menu item to a lcd display, i needed an is_current function implemented. I am using it in the render like this:
```cpp
void MyRenderer::render_numeric_menu_item(NumericMenuItem const& menu_item) const
{
    String buffer;

    buffer = menu_item.get_name();
    buffer += menu_item.has_focus() ? '<' : '=';

    // TODO: get_value_string is a poor name. get_formatted_value maybe?
    buffer += menu_item.get_value_string();

    if (menu_item.has_focus())
        buffer += '>';

    Serial.print(buffer);
    
    if(menu_item.is_current()) {
        lcdDisplayPtr->printTopline(menu_item.get_name());
        
        String lcdBuffer;
        lcdBuffer += menu_item.has_focus() ? '<' : '=';
        lcdBuffer += menu_item.get_value_string();
        if (menu_item.has_focus()) {
            lcdBuffer += '>';
        }
        lcdDisplayPtr->printBottomline(lcdBuffer);
    }
}
```

Also i needed to set the min and max values during runtime. See the separate commit.

Here you find the pull request with these additions, for you to consider this merge request.

Thanks you and best regards,
Arne.