### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
-Menu                    KEYWORD1
-MenuItem                KEYWORD1
-NumericMenuItem         KEYWORD1
-BackMenuItem            KEYWORD1
-MenuSystem              KEYWORD1
-MenuComponent           KEYWORD1
-MenuComponentRenderer   KEYWORD1
+Menu	KEYWORD1
+MenuItem	KEYWORD1
+NumericMenuItem	KEYWORD1
+BackMenuItem	KEYWORD1
+MenuSystem	KEYWORD1
+MenuComponent	KEYWORD1
+MenuComponentRenderer	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords