### PR TITLE
FEATURE: adding has_focus method to NumericMenuItem

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -347,6 +347,10 @@ bool NumericMenuItem::prev(bool loop) {
     return true;
 }
 
+bool NumericMenuItem::has_focus() {
+	return _has_focus;
+}
+
 // *********************************************************
 // MenuSystem
 // *********************************************************

--- a/MenuSystem.h
+++ b/MenuSystem.h
@@ -278,6 +278,8 @@ public:
 
     virtual void render(MenuComponentRenderer const& renderer) const;
 
+    bool has_focus();
+
 protected:
     virtual bool next(bool loop=false);
     virtual bool prev(bool loop=false);


### PR DESCRIPTION
Because i like to have different renderings if a NumericMenuItem has focus or not, i added this method to use in the renderer.